### PR TITLE
大佬，发现您的项目引入了org.quartz-scheduler:quartz@2.2.1组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.wsp</groupId>
@@ -20,7 +18,7 @@
         <dependency>
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz</artifactId>
-            <version>2.2.1</version>
+            <version>2.3.2</version>
         </dependency>
         <dependency>
             <groupId>org.quartz-scheduler</groupId>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Terracotta Quartz Scheduler代码问题漏洞
缺陷组件：org.quartz-scheduler:quartz@2.2.1
漏洞编号：CVE-2019-13990
漏洞描述：Terracotta Quartz Scheduler是一款开源的作业调度框架。
Terracotta Quartz Scheduler存在代码问题漏洞。该漏洞源于网络系统或产品的代码开发过程中存在设计或实现不当的问题。攻击者可通过作业描述利用该漏洞进行XXE攻击。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2020-22364
影响范围：(∞, 2.3.2)
最小修复版本：2.3.2
缺陷组件引入路径：com.wsp:cluster-quartz@1.0-SNAPSHOT->org.quartz-scheduler:quartz@2.2.1
```
另外我运行这个项目时，IDE的安全插件提示还有78个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=pa4ffd